### PR TITLE
feat: apply custom scoreboard styles to Header, Footer, and Scoreboar…

### DIFF
--- a/src/app/individual-scoreboard-view/components/ScoreboardHeader.tsx
+++ b/src/app/individual-scoreboard-view/components/ScoreboardHeader.tsx
@@ -13,26 +13,37 @@ const ScoreboardHeader: React.FC<ScoreboardHeaderProps> = ({ title, description,
     <div 
       className="border-b"
       style={{
-        backgroundColor: customStyles?.headerColor || 'var(--surface)',
+        backgroundColor: customStyles?.backgroundColor || 'var(--surface)',
         borderColor: customStyles?.borderColor || 'var(--border)',
+        fontFamily: customStyles?.fontFamily || 'inherit',
+        borderRadius: customStyles?.borderRadius || '0px',
       }}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <h1 
           className="text-3xl sm:text-4xl font-bold mb-3"
-          style={{ color: customStyles?.headerTextColor || customStyles?.textColor || 'var(--text-primary)' }}
+          style={{ 
+            color: customStyles?.headerTextColor || customStyles?.textColor || 'var(--text-primary)',
+            fontFamily: customStyles?.fontFamily || 'inherit',
+          }}
         >
           {title}
         </h1>
         <p 
           className="text-base sm:text-lg mb-4 max-w-3xl"
-          style={{ color: customStyles?.textColor ? `${customStyles.textColor}99` : 'var(--text-secondary)' }}
+          style={{ 
+            color: customStyles?.headerTextColor ? `${customStyles.headerTextColor}99` : 'var(--text-secondary)',
+            fontFamily: customStyles?.fontFamily || 'inherit',
+          }}
         >
           {description}
         </p>
         <div 
           className="flex items-center space-x-2 text-sm"
-          style={{ color: customStyles?.textColor ? `${customStyles.textColor}99` : 'var(--text-secondary)' }}
+          style={{ 
+            color: customStyles?.headerTextColor ? `${customStyles.headerTextColor}99` : 'var(--text-secondary)',
+            fontFamily: customStyles?.fontFamily || 'inherit',
+          }}
         >
           <span className="font-medium">Total Entries:</span>
           <span 
@@ -40,6 +51,8 @@ const ScoreboardHeader: React.FC<ScoreboardHeaderProps> = ({ title, description,
             style={{
               backgroundColor: customStyles?.accentColor || 'var(--muted)',
               color: customStyles?.accentColor ? '#ffffff' : 'var(--text-primary)',
+              fontFamily: customStyles?.fontFamily || 'inherit',
+              borderRadius: customStyles?.borderRadius || '4px',
             }}
           >
             {totalEntries}

--- a/src/app/individual-scoreboard-view/components/ScoreboardInteractive.tsx
+++ b/src/app/individual-scoreboard-view/components/ScoreboardInteractive.tsx
@@ -13,7 +13,7 @@ import LoadingSkeleton from './LoadingSkeleton';
 import ScoreboardHeader from './ScoreboardHeader';
 import { scoreboardService } from '@/services/scoreboardService';
 import { Scoreboard, ScoreboardEntry, ScoreboardCustomStyles } from '@/types/models';
-import { getStylePreset } from '@/utils/stylePresets';
+import { getAppliedScoreboardStyles } from '@/utils/stylePresets';
 
 interface EntryWithRank extends ScoreboardEntry {
   rank: number;
@@ -178,22 +178,7 @@ const ScoreboardInteractive: React.FC = () => {
   };
 
   const getAppliedStyles = (): ScoreboardCustomStyles | null => {
-    const lightPreset = getStylePreset('light');
-    
-    if (!scoreboard?.customStyles) {
-      return null;
-    }
-    
-    if (!shouldApplyStyles(scoreboard.styleScope)) {
-      return null;
-    }
-    
-    if (scoreboard.customStyles.preset) {
-      const presetStyles = getStylePreset(scoreboard.customStyles.preset);
-      return { ...presetStyles, ...scoreboard.customStyles };
-    }
-    
-    return { ...lightPreset, ...scoreboard.customStyles };
+    return getAppliedScoreboardStyles(scoreboard, 'main');
   };
 
   if (!isHydrated || isLoading) {

--- a/src/app/individual-scoreboard-view/components/ScoreboardViewLayout.tsx
+++ b/src/app/individual-scoreboard-view/components/ScoreboardViewLayout.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Header from '@/components/common/Header';
+import Footer from '@/components/common/Footer';
+import ScoreboardInteractive from './ScoreboardInteractive';
+import LoadingSkeleton from './LoadingSkeleton';
+import { scoreboardService } from '@/services/scoreboardService';
+import { Scoreboard, ScoreboardCustomStyles } from '@/types/models';
+import { getAppliedScoreboardStyles } from '@/utils/stylePresets';
+
+const ScoreboardViewLayout: React.FC = () => {
+  const searchParams = useSearchParams();
+  const scoreboardId = searchParams?.get('id') || null;
+  
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [scoreboard, setScoreboard] = useState<Scoreboard | null>(null);
+  const [appliedStyles, setAppliedStyles] = useState<ScoreboardCustomStyles | null>(null);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    const loadScoreboard = async () => {
+      if (!isHydrated || !scoreboardId) return;
+      
+      setIsLoading(true);
+      try {
+        const { data } = await scoreboardService.getScoreboard(scoreboardId);
+        setScoreboard(data);
+        
+        if (data) {
+          const styles = getAppliedScoreboardStyles(data, 'main');
+          setAppliedStyles(styles);
+        }
+      } catch {
+        // Error handled in ScoreboardInteractive
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadScoreboard();
+  }, [isHydrated, scoreboardId]);
+
+  if (!isHydrated || isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col">
+        <Header isAuthenticated={false} />
+        <main className="pt-16 flex-1">
+          <LoadingSkeleton />
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <Header isAuthenticated={false} customStyles={appliedStyles} />
+      
+      <main className="pt-16 flex-1">
+        <ScoreboardInteractive />
+      </main>
+
+      <Footer customStyles={appliedStyles} />
+    </div>
+  );
+};
+
+export default ScoreboardViewLayout;

--- a/src/app/individual-scoreboard-view/page.tsx
+++ b/src/app/individual-scoreboard-view/page.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import Header from '@/components/common/Header';
-import Footer from '@/components/common/Footer';
-import ScoreboardInteractive from './components/ScoreboardInteractive';
-import LoadingSkeleton from './components/LoadingSkeleton';
+import ScoreboardViewLayout from './components/ScoreboardViewLayout';
 
 export const metadata: Metadata = {
   title: 'Scoreboard View - Scoreboard Manager',
@@ -12,16 +9,8 @@ export const metadata: Metadata = {
 
 export default function IndividualScoreboardViewPage() {
   return (
-    <div className="min-h-screen bg-background flex flex-col">
-      <Header isAuthenticated={false} />
-      
-      <main className="pt-16 flex-1">
-        <Suspense fallback={<LoadingSkeleton />}>
-          <ScoreboardInteractive />
-        </Suspense>
-      </main>
-
-      <Footer />
-    </div>
+    <Suspense fallback={<div className="min-h-screen bg-background" />}>
+      <ScoreboardViewLayout />
+    </Suspense>
   );
 }

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,88 +1,109 @@
 import Link from 'next/link';
 import Logo from '@/components/ui/Logo';
+import { ScoreboardCustomStyles } from '@/types/models';
 
-export default function Footer() {
+interface FooterProps {
+  customStyles?: ScoreboardCustomStyles | null;
+}
+
+export default function Footer({ customStyles = null }: FooterProps) {
+  const footerStyle = {
+    backgroundColor: customStyles?.backgroundColor || 'var(--surface)',
+    borderColor: customStyles?.borderColor || 'var(--border)',
+    fontFamily: customStyles?.fontFamily || 'inherit',
+  };
+
+  const textStyle = {
+    color: customStyles?.textColor || 'var(--text-secondary)',
+    fontFamily: customStyles?.fontFamily || 'inherit',
+  };
+
+  const headingStyle = {
+    color: customStyles?.textColor || 'var(--text-primary)',
+    fontFamily: customStyles?.fontFamily || 'inherit',
+  };
+
   return (
-    <footer className="bg-surface border-t border-border mt-auto">
+    <footer className="border-t mt-auto" style={footerStyle}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="grid md:grid-cols-4 gap-8 mb-8">
           <div>
             <div className="flex items-center space-x-3 mb-4">
               <Logo size={36} />
-              <span className="text-lg font-bold text-text-primary">Scoreboard Manager</span>
+              <span className="text-lg font-bold" style={headingStyle}>Scoreboard Manager</span>
             </div>
-            <p className="text-text-secondary text-sm">
+            <p className="text-sm" style={textStyle}>
               Professional scoreboard management for tournaments, leagues, and competitions.
             </p>
           </div>
           <div>
-            <h4 className="font-semibold text-text-primary mb-4">Product</h4>
-            <ul className="space-y-2 text-sm text-text-secondary">
+            <h4 className="font-semibold mb-4" style={headingStyle}>Product</h4>
+            <ul className="space-y-2 text-sm" style={textStyle}>
               <li>
-                <Link href="/#features" className="hover:text-primary transition-colors">
+                <Link href="/#features" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Features
                 </Link>
               </li>
               <li>
-                <Link href="/public-scoreboard-list" className="hover:text-primary transition-colors">
+                <Link href="/public-scoreboard-list" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Scoreboards
                 </Link>
               </li>
               <li>
-                <Link href="/login" className="hover:text-primary transition-colors">
+                <Link href="/login" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Login
                 </Link>
               </li>
               <li>
-                <Link href="/register" className="hover:text-primary transition-colors">
+                <Link href="/register" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Sign Up
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-semibold text-text-primary mb-4">Company</h4>
-            <ul className="space-y-2 text-sm text-text-secondary">
+            <h4 className="font-semibold mb-4" style={headingStyle}>Company</h4>
+            <ul className="space-y-2 text-sm" style={textStyle}>
               <li>
-                <Link href="/about" className="hover:text-primary transition-colors">
+                <Link href="/about" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   About Us
                 </Link>
               </li>
               <li>
-                <Link href="/contact" className="hover:text-primary transition-colors">
+                <Link href="/contact" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Contact
                 </Link>
               </li>
               <li>
-                <Link href="/support" className="hover:text-primary transition-colors">
+                <Link href="/support" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Support
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-semibold text-text-primary mb-4">Legal</h4>
-            <ul className="space-y-2 text-sm text-text-secondary">
+            <h4 className="font-semibold mb-4" style={headingStyle}>Legal</h4>
+            <ul className="space-y-2 text-sm" style={textStyle}>
               <li>
-                <Link href="/privacy" className="hover:text-primary transition-colors">
+                <Link href="/privacy" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Privacy Policy
                 </Link>
               </li>
               <li>
-                <Link href="/terms" className="hover:text-primary transition-colors">
+                <Link href="/terms" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Terms of Service
                 </Link>
               </li>
               <li>
-                <Link href="/cookies" className="hover:text-primary transition-colors">
+                <Link href="/cookies" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
                   Cookie Policy
                 </Link>
               </li>
             </ul>
           </div>
         </div>
-        <div className="pt-8 border-t border-border text-center">
-          <p className="text-sm text-text-secondary">
+        <div className="pt-8 text-center" style={{ borderTop: `1px solid ${customStyles?.borderColor || 'var(--border)'}` }}>
+          <p className="text-sm" style={textStyle}>
             &copy; {new Date()?.getFullYear()} Scoreboard Manager. All rights reserved.
           </p>
         </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -6,18 +6,36 @@ import { usePathname, useRouter } from 'next/navigation';
 import Icon from '@/components/ui/AppIcon';
 import Logo from '@/components/ui/Logo';
 import { useAuth } from '@/contexts/AuthContext';
+import { ScoreboardCustomStyles } from '@/types/models';
 
 interface HeaderProps {
   isAuthenticated?: boolean;
   onLogout?: () => void;
+  customStyles?: ScoreboardCustomStyles | null;
 }
 
-const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
+const Header = ({ isAuthenticated = false, onLogout, customStyles = null }: HeaderProps) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
   const { userProfile, user, signOut } = useAuth();
+
+  const headerStyle = {
+    backgroundColor: customStyles?.backgroundColor || 'var(--surface)',
+    borderColor: customStyles?.borderColor || 'var(--border)',
+    fontFamily: customStyles?.fontFamily || 'inherit',
+  };
+
+  const textStyle = {
+    color: customStyles?.textColor || 'var(--text-secondary)',
+    fontFamily: customStyles?.fontFamily || 'inherit',
+  };
+
+  const accentStyle = {
+    backgroundColor: customStyles?.accentColor || 'var(--primary)',
+    fontFamily: customStyles?.fontFamily || 'inherit',
+  };
 
   useEffect(() => {
     setIsMobileMenuOpen(false);
@@ -48,7 +66,7 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
   const displayName = userProfile?.fullName || user?.email || 'User';
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-[1000] bg-surface border-b border-border elevation-1">
+    <header className="fixed top-0 left-0 right-0 z-[1000] border-b elevation-1" style={headerStyle}>
       <nav className="mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">
@@ -71,28 +89,32 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
               <>
                 <Link
                   href="/#features"
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                 >
                   <Icon name="SparklesIcon" size={18} />
                   <span>Features</span>
                 </Link>
                 <Link
                   href="/#benefits"
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                 >
                   <Icon name="CheckBadgeIcon" size={18} />
                   <span>Benefits</span>
                 </Link>
                 <Link
                   href="/#testimonials"
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                 >
                   <Icon name="ChatBubbleLeftRightIcon" size={18} />
                   <span>Testimonials</span>
                 </Link>
                 <Link
                   href="/public-scoreboard-list"
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                 >
                   <Icon name="TrophyIcon" size={18} />
                   <span>Scoreboards</span>
@@ -103,12 +125,13 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
               <div className="relative">
                 <button
                   onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                   aria-label="User menu"
                   aria-expanded={isUserMenuOpen}
                 >
-                  <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center">
-                    <Icon name="UserIcon" size={18} className="text-primary-foreground" />
+                  <div className="w-8 h-8 rounded-full flex items-center justify-center" style={accentStyle}>
+                    <Icon name="UserIcon" size={18} className="text-white" />
                   </div>
                   <span className="text-sm font-medium">{displayName}</span>
                   <Icon
@@ -124,12 +147,13 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                       className="fixed inset-0 z-[1009]"
                       onClick={() => setIsUserMenuOpen(false)}
                     />
-                    <div className="absolute right-0 mt-2 w-48 bg-popover border border-border rounded-md elevation-2 z-[1010]">
+                    <div className="absolute right-0 mt-2 w-48 border rounded-md elevation-2 z-[1010]" style={{ backgroundColor: customStyles?.backgroundColor || 'var(--popover)', borderColor: customStyles?.borderColor || 'var(--border)' }}>
                       <div className="py-1">
                         <Link
                           href="/dashboard"
                           onClick={() => setIsUserMenuOpen(false)}
-                          className="flex items-center w-full px-4 py-2 text-sm text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                          className="flex items-center w-full px-4 py-2 text-sm hover:opacity-80 transition-smooth duration-150"
+                          style={textStyle}
                         >
                           <Icon name="ClipboardDocumentListIcon" size={18} className="mr-3" />
                           My Boards
@@ -137,7 +161,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                         <Link
                           href="/user-profile-management"
                           onClick={() => setIsUserMenuOpen(false)}
-                          className="flex items-center w-full px-4 py-2 text-sm text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                          className="flex items-center w-full px-4 py-2 text-sm hover:opacity-80 transition-smooth duration-150"
+                          style={textStyle}
                         >
                           <Icon name="UserCircleIcon" size={18} className="mr-3" />
                           Profile
@@ -145,7 +170,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                         <Link
                           href="/invitations"
                           onClick={() => setIsUserMenuOpen(false)}
-                          className="flex items-center w-full px-4 py-2 text-sm text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                          className="flex items-center w-full px-4 py-2 text-sm hover:opacity-80 transition-smooth duration-150"
+                          style={textStyle}
                         >
                           <Icon name="EnvelopeIcon" size={18} className="mr-3" />
                           Invitations
@@ -154,7 +180,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                           <Link
                             href="/system-admin/settings"
                             onClick={() => setIsUserMenuOpen(false)}
-                            className="flex items-center w-full px-4 py-2 text-sm text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                            className="flex items-center w-full px-4 py-2 text-sm hover:opacity-80 transition-smooth duration-150"
+                            style={textStyle}
                           >
                             <Icon name="Cog6ToothIcon" size={18} className="mr-3" />
                             System Settings
@@ -162,7 +189,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                         )}
                         <button
                           onClick={handleLogout}
-                          className="flex items-center w-full px-4 py-2 text-sm text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                          className="flex items-center w-full px-4 py-2 text-sm hover:opacity-80 transition-smooth duration-150"
+                          style={textStyle}
                         >
                           <Icon name="ArrowRightOnRectangleIcon" size={18} className="mr-3" />
                           Logout
@@ -176,14 +204,21 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
               <>
                 <Link
                   href="/register"
-                  className="flex items-center space-x-2 px-4 py-2 rounded-md text-sm font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150 hover-lift border border-border"
+                  className="flex items-center space-x-2 px-4 py-2 rounded-md text-sm font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={{
+                    color: customStyles?.textColor || 'var(--text-secondary)',
+                    borderColor: customStyles?.borderColor || 'var(--border)',
+                    borderWidth: '1px',
+                    fontFamily: customStyles?.fontFamily || 'inherit',
+                  }}
                 >
                   <Icon name="UserPlusIcon" size={18} />
                   <span>Sign Up</span>
                 </Link>
                 <Link
                   href="/login"
-                  className="flex items-center space-x-2 px-4 py-2 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-smooth duration-150 hover-lift"
+                  className="flex items-center space-x-2 px-4 py-2 rounded-md text-sm font-medium text-white hover:opacity-90 transition-smooth duration-150 hover-lift"
+                  style={accentStyle}
                 >
                   <Icon name="ArrowRightOnRectangleIcon" size={18} />
                   <span>Login</span>
@@ -195,7 +230,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
           <div className="md:hidden flex items-center">
             <button
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="p-2 rounded-md text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+              className="p-2 rounded-md hover:opacity-80 transition-smooth duration-150"
+              style={textStyle}
               aria-label="Toggle menu"
               aria-expanded={isMobileMenuOpen}
             >
@@ -205,12 +241,13 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
         </div>
 
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t border-border">
+          <div className="md:hidden border-t" style={{ borderColor: customStyles?.borderColor || 'var(--border)' }}>
             {!isAuthenticated && (
               <div className="px-2 pt-2 pb-3 space-y-1">
                 <Link
                   href="/"
-                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <Icon name="HomeIcon" size={20} />
@@ -218,7 +255,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                 </Link>
                 <Link
                   href="/#features"
-                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <Icon name="SparklesIcon" size={20} />
@@ -226,7 +264,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                 </Link>
                 <Link
                   href="/#benefits"
-                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <Icon name="CheckBadgeIcon" size={20} />
@@ -234,7 +273,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                 </Link>
                 <Link
                   href="/#testimonials"
-                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <Icon name="ChatBubbleLeftRightIcon" size={20} />
@@ -242,7 +282,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                 </Link>
                 <Link
                   href="/public-scoreboard-list"
-                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                  className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                  style={textStyle}
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <Icon name="TrophyIcon" size={20} />
@@ -251,21 +292,22 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
               </div>
             )}
 
-            <div className="border-t border-border px-2 pt-4 pb-3">
+            <div className="border-t px-2 pt-4 pb-3" style={{ borderColor: customStyles?.borderColor || 'var(--border)' }}>
               {isAuthenticated ? (
                 <div className="space-y-1">
                   <div className="flex items-center px-3 py-2">
-                    <div className="w-10 h-10 rounded-full bg-primary flex items-center justify-center">
-                      <Icon name="UserIcon" size={20} className="text-primary-foreground" />
+                    <div className="w-10 h-10 rounded-full flex items-center justify-center" style={accentStyle}>
+                      <Icon name="UserIcon" size={20} className="text-white" />
                     </div>
-                    <span className="ml-3 text-base font-medium text-text-primary">
+                    <span className="ml-3 text-base font-medium" style={{ color: customStyles?.textColor || 'var(--text-primary)' }}>
                       {displayName}
                     </span>
                   </div>
                   <Link
                     href="/dashboard"
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                    style={textStyle}
                   >
                     <Icon name="ClipboardDocumentListIcon" size={20} className="mr-3" />
                     My Boards
@@ -273,7 +315,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                   <Link
                     href="/user-profile-management"
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                    style={textStyle}
                   >
                     <Icon name="UserCircleIcon" size={20} className="mr-3" />
                     Profile
@@ -281,7 +324,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                   <Link
                     href="/invitations"
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                    style={textStyle}
                   >
                     <Icon name="EnvelopeIcon" size={20} className="mr-3" />
                     Invitations
@@ -290,7 +334,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                     <Link
                       href="/system-admin/settings"
                       onClick={() => setIsMobileMenuOpen(false)}
-                      className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                      className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                      style={textStyle}
                     >
                       <Icon name="Cog6ToothIcon" size={20} className="mr-3" />
                       System Settings
@@ -298,7 +343,8 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                   )}
                   <button
                     onClick={handleLogout}
-                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150"
+                    className="flex items-center w-full px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                    style={textStyle}
                   >
                     <Icon name="ArrowRightOnRectangleIcon" size={20} className="mr-3" />
                     Logout
@@ -308,14 +354,21 @@ const Header = ({ isAuthenticated = false, onLogout }: HeaderProps) => {
                 <div className="space-y-2">
                   <Link
                     href="/register"
-                    className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-text-secondary hover:bg-muted hover:text-text-primary transition-smooth duration-150 border border-border"
+                    className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium hover:opacity-80 transition-smooth duration-150"
+                    style={{
+                      color: customStyles?.textColor || 'var(--text-secondary)',
+                      borderColor: customStyles?.borderColor || 'var(--border)',
+                      borderWidth: '1px',
+                      fontFamily: customStyles?.fontFamily || 'inherit',
+                    }}
                   >
                     <Icon name="UserPlusIcon" size={20} />
                     <span>Sign Up</span>
                   </Link>
                   <Link
                     href="/login"
-                    className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium bg-primary text-primary-foreground hover:opacity-90 transition-smooth duration-150"
+                    className="flex items-center space-x-3 px-3 py-2 rounded-md text-base font-medium text-white hover:opacity-90 transition-smooth duration-150"
+                    style={accentStyle}
                   >
                     <Icon name="ArrowRightOnRectangleIcon" size={20} />
                     <span>Login</span>

--- a/src/utils/stylePresets.ts
+++ b/src/utils/stylePresets.ts
@@ -150,6 +150,34 @@ export function getStylePreset(preset: string): ScoreboardCustomStyles {
   return STYLE_PRESETS[preset] || STYLE_PRESETS.light;
 }
 
+export function getAppliedScoreboardStyles(
+  scoreboard: { customStyles?: ScoreboardCustomStyles | null; styleScope?: 'main' | 'embed' | 'both' } | null | undefined,
+  scope: 'main' | 'embed' = 'main'
+): ScoreboardCustomStyles | null {
+  const lightPreset = getStylePreset('light');
+  
+  if (!scoreboard?.customStyles) {
+    return null;
+  }
+  
+  const shouldApplyStyles = (scoreScope?: 'main' | 'embed' | 'both') => {
+    if (scope === 'main') return scoreScope === 'main' || scoreScope === 'both';
+    if (scope === 'embed') return scoreScope === 'embed' || scoreScope === 'both' || !scoreScope;
+    return false;
+  };
+  
+  if (!shouldApplyStyles(scoreboard.styleScope)) {
+    return null;
+  }
+  
+  if (scoreboard.customStyles.preset) {
+    const presetStyles = getStylePreset(scoreboard.customStyles.preset);
+    return { ...presetStyles, ...scoreboard.customStyles };
+  }
+  
+  return { ...lightPreset, ...scoreboard.customStyles };
+}
+
 export function generateCustomStyles(styles: ScoreboardCustomStyles): React.CSSProperties {
   return {
     '--embed-bg': styles.backgroundColor,


### PR DESCRIPTION
…dHeader components

- Add getAppliedScoreboardStyles() utility in stylePresets.ts for shared style computation
- Update ScoreboardHeader to apply all custom style properties: backgroundColor, borderColor, fontFamily, borderRadius, textColor
- Update Header component to accept customStyles prop and apply to navigation elements (except logo/branding)
- Update Footer component to accept customStyles prop and apply to all text and links (except logo/branding)
- Create ScoreboardViewLayout wrapper component to compute styles and pass to Header/Footer
- Update individual-scoreboard-view page to use new ScoreboardViewLayout
- Refactor ScoreboardInteractive to use getAppliedScoreboardStyles() utility
- Implement scope filtering for main vs embed views
- Add proper fallback to Tailwind CSS variables for pages without custom styles
- All elements use inline styles with consistent opacity-based hover states