### PR TITLE
fix: conditionally apply inline styles to prevent Tailwind defaults f…

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -7,103 +7,103 @@ interface FooterProps {
 }
 
 export default function Footer({ customStyles = null }: FooterProps) {
-  const footerStyle = {
-    backgroundColor: customStyles?.backgroundColor || 'var(--surface)',
-    borderColor: customStyles?.borderColor || 'var(--border)',
-    fontFamily: customStyles?.fontFamily || 'inherit',
-  };
+  const footerStyle = customStyles ? {
+    backgroundColor: customStyles.backgroundColor,
+    borderColor: customStyles.borderColor,
+    fontFamily: customStyles.fontFamily || 'inherit',
+  } : undefined;
 
-  const textStyle = {
-    color: customStyles?.textColor || 'var(--text-secondary)',
-    fontFamily: customStyles?.fontFamily || 'inherit',
-  };
+  const textStyle = customStyles ? {
+    color: customStyles.textColor,
+    fontFamily: customStyles.fontFamily || 'inherit',
+  } : undefined;
 
-  const headingStyle = {
-    color: customStyles?.textColor || 'var(--text-primary)',
-    fontFamily: customStyles?.fontFamily || 'inherit',
-  };
+  const headingStyle = customStyles ? {
+    color: customStyles.textColor,
+    fontFamily: customStyles.fontFamily || 'inherit',
+  } : undefined;
 
   return (
-    <footer className="border-t mt-auto" style={footerStyle}>
+    <footer className="border-t border-border bg-surface mt-auto" style={customStyles ? footerStyle : undefined}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="grid md:grid-cols-4 gap-8 mb-8">
           <div>
             <div className="flex items-center space-x-3 mb-4">
               <Logo size={36} />
-              <span className="text-lg font-bold" style={headingStyle}>Scoreboard Manager</span>
+              <span className="text-lg font-bold text-text-primary" style={customStyles ? headingStyle : undefined}>Scoreboard Manager</span>
             </div>
-            <p className="text-sm" style={textStyle}>
+            <p className="text-sm text-text-secondary" style={customStyles ? textStyle : undefined}>
               Professional scoreboard management for tournaments, leagues, and competitions.
             </p>
           </div>
           <div>
-            <h4 className="font-semibold mb-4" style={headingStyle}>Product</h4>
-            <ul className="space-y-2 text-sm" style={textStyle}>
+            <h4 className="font-semibold mb-4 text-text-primary" style={customStyles ? headingStyle : undefined}>Product</h4>
+            <ul className="space-y-2 text-sm text-text-secondary" style={customStyles ? textStyle : undefined}>
               <li>
-                <Link href="/#features" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/#features" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Features
                 </Link>
               </li>
               <li>
-                <Link href="/public-scoreboard-list" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/public-scoreboard-list" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Scoreboards
                 </Link>
               </li>
               <li>
-                <Link href="/login" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/login" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Login
                 </Link>
               </li>
               <li>
-                <Link href="/register" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/register" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Sign Up
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-semibold mb-4" style={headingStyle}>Company</h4>
-            <ul className="space-y-2 text-sm" style={textStyle}>
+            <h4 className="font-semibold mb-4 text-text-primary" style={customStyles ? headingStyle : undefined}>Company</h4>
+            <ul className="space-y-2 text-sm text-text-secondary" style={customStyles ? textStyle : undefined}>
               <li>
-                <Link href="/about" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/about" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   About Us
                 </Link>
               </li>
               <li>
-                <Link href="/contact" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/contact" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Contact
                 </Link>
               </li>
               <li>
-                <Link href="/support" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/support" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Support
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-semibold mb-4" style={headingStyle}>Legal</h4>
-            <ul className="space-y-2 text-sm" style={textStyle}>
+            <h4 className="font-semibold mb-4 text-text-primary" style={customStyles ? headingStyle : undefined}>Legal</h4>
+            <ul className="space-y-2 text-sm text-text-secondary" style={customStyles ? textStyle : undefined}>
               <li>
-                <Link href="/privacy" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/privacy" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Privacy Policy
                 </Link>
               </li>
               <li>
-                <Link href="/terms" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/terms" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Terms of Service
                 </Link>
               </li>
               <li>
-                <Link href="/cookies" className="hover:opacity-80 transition-opacity" style={{ color: customStyles?.textColor || 'var(--text-secondary)' }}>
+                <Link href="/cookies" className="hover:opacity-80 transition-opacity text-text-secondary" style={customStyles ? { color: customStyles.textColor } : undefined}>
                   Cookie Policy
                 </Link>
               </li>
             </ul>
           </div>
         </div>
-        <div className="pt-8 text-center" style={{ borderTop: `1px solid ${customStyles?.borderColor || 'var(--border)'}` }}>
-          <p className="text-sm" style={textStyle}>
+        <div className="pt-8 text-center border-t border-border" style={customStyles ? { borderColor: customStyles.borderColor } : undefined}>
+          <p className="text-sm text-text-secondary" style={customStyles ? textStyle : undefined}>
             &copy; {new Date()?.getFullYear()} Scoreboard Manager. All rights reserved.
           </p>
         </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -21,21 +21,21 @@ const Header = ({ isAuthenticated = false, onLogout, customStyles = null }: Head
   const router = useRouter();
   const { userProfile, user, signOut } = useAuth();
 
-  const headerStyle = {
-    backgroundColor: customStyles?.backgroundColor || 'var(--surface)',
-    borderColor: customStyles?.borderColor || 'var(--border)',
-    fontFamily: customStyles?.fontFamily || 'inherit',
-  };
+  const headerStyle = customStyles ? {
+    backgroundColor: customStyles.backgroundColor,
+    borderColor: customStyles.borderColor,
+    fontFamily: customStyles.fontFamily || 'inherit',
+  } : undefined;
 
-  const textStyle = {
-    color: customStyles?.textColor || 'var(--text-secondary)',
-    fontFamily: customStyles?.fontFamily || 'inherit',
-  };
+  const textStyle = customStyles ? {
+    color: customStyles.textColor,
+    fontFamily: customStyles.fontFamily || 'inherit',
+  } : undefined;
 
-  const accentStyle = {
-    backgroundColor: customStyles?.accentColor || 'var(--primary)',
-    fontFamily: customStyles?.fontFamily || 'inherit',
-  };
+  const accentStyle = customStyles ? {
+    backgroundColor: customStyles.accentColor,
+    fontFamily: customStyles.fontFamily || 'inherit',
+  } : undefined;
 
   useEffect(() => {
     setIsMobileMenuOpen(false);
@@ -66,7 +66,7 @@ const Header = ({ isAuthenticated = false, onLogout, customStyles = null }: Head
   const displayName = userProfile?.fullName || user?.email || 'User';
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-[1000] border-b elevation-1" style={headerStyle}>
+    <header className="fixed top-0 left-0 right-0 z-[1000] border-b border-border bg-surface elevation-1" style={customStyles ? headerStyle : undefined}>
       <nav className="mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">
@@ -147,7 +147,7 @@ const Header = ({ isAuthenticated = false, onLogout, customStyles = null }: Head
                       className="fixed inset-0 z-[1009]"
                       onClick={() => setIsUserMenuOpen(false)}
                     />
-                    <div className="absolute right-0 mt-2 w-48 border rounded-md elevation-2 z-[1010]" style={{ backgroundColor: customStyles?.backgroundColor || 'var(--popover)', borderColor: customStyles?.borderColor || 'var(--border)' }}>
+                    <div className="absolute right-0 mt-2 w-48 border border-border rounded-md elevation-2 z-[1010] bg-popover" style={customStyles ? { backgroundColor: customStyles.backgroundColor, borderColor: customStyles.borderColor } : undefined}>
                       <div className="py-1">
                         <Link
                           href="/dashboard"
@@ -241,7 +241,7 @@ const Header = ({ isAuthenticated = false, onLogout, customStyles = null }: Head
         </div>
 
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t" style={{ borderColor: customStyles?.borderColor || 'var(--border)' }}>
+          <div className="md:hidden border-t border-border" style={customStyles ? { borderColor: customStyles.borderColor } : undefined}>
             {!isAuthenticated && (
               <div className="px-2 pt-2 pb-3 space-y-1">
                 <Link
@@ -292,7 +292,7 @@ const Header = ({ isAuthenticated = false, onLogout, customStyles = null }: Head
               </div>
             )}
 
-            <div className="border-t px-2 pt-4 pb-3" style={{ borderColor: customStyles?.borderColor || 'var(--border)' }}>
+            <div className="border-t border-border px-2 pt-4 pb-3" style={customStyles ? { borderColor: customStyles.borderColor } : undefined}>
               {isAuthenticated ? (
                 <div className="space-y-1">
                   <div className="flex items-center px-3 py-2">


### PR DESCRIPTION
…rom being overridden

- Header.tsx: Only apply inline styles when customStyles is provided, otherwise use Tailwind classes (bg-surface, border-border, text-text-secondary)
- Footer.tsx: Same conditional styling approach for all footer elements
- Added Tailwind utility classes to all components for default styling
- Fixes styling regression on all pages where Header/Footer are used without customStyles
- When customStyles is null, style attribute is not applied, allowing Tailwind classes to work correctly
- When customStyles is provided (scoreboard view pages), inline styles take precedence for customization
- Changes affect: header background/border/text, footer background/border/text, nav links, user menu, footer links, and all text elements