### PR TITLE
fix: update Supabase CLI download URL to use latest release

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
 
 # Production settings - runs migrations before build
 [context.production]
-  command = "curl -sSL https://github.com/supabase/cli/releases/download/v1.200.3/supabase_1.200.3_linux_amd64.tar.gz | tar -xz && chmod +x supabase && ./supabase link --project-ref \"$SUPABASE_PROJECT_REF\" && ./supabase db push && npm run build"
+  command = "curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz | tar -xz --strip-components=1 && chmod +x supabase && ./supabase link --project-ref \"$SUPABASE_PROJECT_REF\" && ./supabase db push && npm run build"
   
 [context.production.environment]
   NEXT_PUBLIC_SITE_URL = "https://myscoreboardmanager.netlify.app"


### PR DESCRIPTION
- Changed from specific version v1.200.3 to latest release endpoint
- Added -f flag to curl for fail-fast on HTTP errors
- Added --strip-components=1 to tar for correct extraction
- Fixes 'gzip: stdin: not in gzip format' error in Netlify builds

The previous URL was returning 404/HTML instead of the tarball. Latest release URL is more reliable and auto-updates.