### PR TITLE
Merge dev into main: PIN input fix, build checks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,10 +3,10 @@ const nextConfig = {
   productionBrowserSourceMaps: true,
   distDir: process.env.DIST_DIR || '.next',
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   // Optimize package imports for better tree-shaking
   experimental: {

--- a/src/app/scoreboard-management/components/KioskSettingsSection.tsx
+++ b/src/app/scoreboard-management/components/KioskSettingsSection.tsx
@@ -1126,6 +1126,7 @@ export default function KioskSettingsSection({
                         setHasChanges(true);
                       }}
                       placeholder="Enter 4-6 digit PIN"
+                      autoComplete="off"
                       className="w-full px-3 py-2 pr-10 bg-background border border-input rounded-md text-text-primary focus:border-primary focus:ring-1 focus:ring-primary"
                     />
                     <button


### PR DESCRIPTION
## Summary

This PR merges the latest changes from dev into main.

### Included Commits

- fix: add autocomplete=off to PIN input to prevent password manager trigger
- fix: re-enable TypeScript and ESLint build checks

### Details
- The PIN input field now has autocomplete=off to prevent browser password managers from interfering with kiosk PIN entry.
- TypeScript and ESLint build checks are re-enabled, restoring type safety and linting to the build process.

Please review and merge for release.